### PR TITLE
Use rho-contracts-fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage
 You must use the Body Labs package, `rho-contracts-fork`:
 ```js
   "dependencies": {
-    "rho-contracts-fork": "^1.2.2"
+    "rho-contracts-fork": "^1.3.0"
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,18 @@ Check URIs with [rho-contracts][].
 Usage
 -----
 
+You must use the Body Labs package, `rho-contracts-fork`:
+```js
+  "dependencies": {
+    "rho-contracts-fork": "^1.2.2"
+  }
+```
+
 ```js
 
 var cc = {};
 
-cc.uri = require('rho-cc-s3-uri');
+cc.uri = require('rho-cc-uri');
 
 // Does not throw.
 cc.uri.check('https://foo/bar');
@@ -27,7 +34,7 @@ Installation
 ------------
 
 ```sh
-npm install rho-contracts rho-cc-uri
+npm install rho-contracts-fork rho-cc-uri
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rho-cc-uri",
   "description": "Check URIs with rho-contracts",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MPL-2.0",
   "main": "uri.js",
   "scripts": {
@@ -20,14 +20,14 @@
     "valid-url": "^1.0.9"
   },
   "peerDependencies": {
-    "rho-contracts": "*"
+    "rho-contracts-fork": "*"
   },
   "devDependencies": {
     "bodylabs-javascript-style": "^4.0.0",
     "eslint": "~2.4.0",
     "jscs": "^2.8.0",
     "mocha": "~2.0.1",
-    "rho-contracts": "git+https://github.com/bodylabs/rho-contracts.js.git#1.2.0",
+    "rho-contracts-fork": "^1.3.0",
     "should": "~8.3.1"
   }
 }

--- a/uri.js
+++ b/uri.js
@@ -1,4 +1,4 @@
-var c = require('rho-contracts'),
+var c = require('rho-contracts-fork'),
     _ = require('underscore');
 
 var isUri = require('valid-url').isUri;

--- a/uri.spec.js
+++ b/uri.spec.js
@@ -1,6 +1,6 @@
 var uri = require('./uri');
 
-var c = require('rho-contracts');
+var c = require('rho-contracts-fork');
 
 var should = require('should');
 


### PR DESCRIPTION
Marked as a major version change, since it requires pulling in a different library. Open to discussing that.

We could make this flexible enough to use either implementation, but it would complicate it, and I think would break `peerDependencies`. Given the dormant state of `rho-contracts`, I think other people using our libraries would probably also want to use our fork – that we should try to form a community around the fork.
